### PR TITLE
change 'today' format to MMM do

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,3 +13,11 @@ $(function() {
         console.log(qDate);
     })
 });
+
+$(function() {
+    $('#todayBtn').on('click', function(t) {
+        t.preventDefault();
+        qDate = moment().format('MMMM Do');
+        console.log(qDate);
+    })
+})


### PR DESCRIPTION
Minor change: Format of "today" date should omit year, so that content queried can be relevant to today's date in years past. 